### PR TITLE
Fix undefined local variable `incident_key`

### DIFF
--- a/bin/handler-fluentd.rb
+++ b/bin/handler-fluentd.rb
@@ -86,14 +86,14 @@ class Fluentd < Sensu::Handler
 
         response = http.request(request)
         if response.code == '200'
-          puts "fluentd -- #{@event['action']} incident -- #{incident_key}"
+          puts "fluentd -- #{@event['action']} incident -- #{event_name}"
         else
-          puts "fluentd -- failed to send #{@event['action']} incident -- #{incident_key}"
+          puts "fluentd -- failed to send #{@event['action']} incident -- #{event_name}"
           puts "fluentd -- response: #{response.inspect}"
         end
       end
     rescue Timeout::Error
-      puts "fluentd -- Timed out while attempting to send #{@event['action']} incident -- #{incident_key}"
+      puts "fluentd -- Timed out while attempting to send #{@event['action']} incident -- #{event_name}"
     end
   end
 end


### PR DESCRIPTION
The `incident_key` is not defined so the plugin throws an exception when used via Sensu.
I replace `incident_key` by `event_name` (a defined property that does the same).
