### PR TITLE
Fix timeout deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -26,8 +27,9 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-fluentd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - handler-fluentd.rb: Fix undefined local variable `incident_key` (@jkernech)
 
+### Changed
+- Update `timeout` method to remove deprecation warnings (@eheydrick)
+
 ## [0.1.0] - 2015-12-03
 ### Added
 - Added timeout option to check-fluentd-monitor-agent.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - Update `timeout` method to remove deprecation warnings (@eheydrick)
 
+### Added
+- Ruby 2.3 and 2.4 support (@eheydrick)
+
+### Removed
+- Ruby 1.9.3 support (@eheydrick)
+
 ## [0.1.0] - 2015-12-03
 ### Added
 - Added timeout option to check-fluentd-monitor-agent.rb

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,6 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
@@ -44,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: args
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]

--- a/bin/check-fluentd-monitor-agent.rb
+++ b/bin/check-fluentd-monitor-agent.rb
@@ -81,7 +81,7 @@ class CheckFluentdMonitorAgent < Sensu::Plugin::Check::CLI
     end
 
     begin
-      timeout(config[:timeout]) do
+      Timeout.timeout(config[:timeout]) do
         acquire_resource
       end
     rescue Timeout::Error

--- a/bin/metric-fluentd-monitor-agent.rb
+++ b/bin/metric-fluentd-monitor-agent.rb
@@ -57,7 +57,7 @@ class MetricFluentdMonitorAgent < Sensu::Plugin::Metric::CLI::Graphite
     end
 
     begin
-      timeout(config[:timeout]) do
+      Timeout.timeout(config[:timeout]) do
         acquire_resource
       end
     rescue Timeout::Error

--- a/sensu-plugins-fluentd.gemspec
+++ b/sensu-plugins-fluentd.gemspec
@@ -2,18 +2,10 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-fluentd'
-else
-  require_relative 'lib/sensu-plugins-fluentd'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-fluentd'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
-  # s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for working with fluentd'
   s.email                  = '<sensu-users@googlegroups.com>'
@@ -30,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for working with fluentd'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist

#7 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Remove deprecation warnings in the `timeout` method. Also remove Ruby 1.9.3 support and add 2.3 and 2.4.
